### PR TITLE
Update download links for free version

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 				
 				<a id="support-header-button" href="https://twitter.com/framerinventory" target="_blank">Support</a>
 				<a id="learn-header-button" href="https://medium.com/framer-inventory?utm_source=site&utm_medium=header" target="_blank">Learn</a>
-				<a id="download-header-track-button" href="https://github.com/timurnurutdinov/Framer-Inventory-for-Sketch/archive/master.zip" download="Framer Inventory 3">Download</a>
+				<a id="download-header-track-button" href="https://sketchpacks-api.herokuapp.com/v1/plugins/com.addleimb.framer-inventory/download" download="Framer Inventory 3">Download</a>
 			</div> 
 		</header>
 
@@ -90,7 +90,7 @@
 
 		<div class="buttons-group welcome-buttons">
 			
-			<a id="welcome-download-track-button" class="button welcome-button-download first-child" href="https://github.com/timurnurutdinov/Framer-Inventory-for-Sketch/archive/master.zip" download="Framer Inventory 3">
+			<a id="welcome-download-track-button" class="button welcome-button-download first-child" href="https://sketchpacks-api.herokuapp.com/v1/plugins/com.addleimb.framer-inventory/download" download="Framer Inventory 3">
 				<p>Download</p>
 			</a>
 			
@@ -312,7 +312,7 @@
 					<p class="pro-features-item">5 runs per day</p>
 					<p class="pro-features-item">50 runs on first day</p>
 					
-					<a id="pro-download-track-button" class="button pro-section-button-download" href="https://github.com/timurnurutdinov/Framer-Inventory-for-Sketch/archive/master.zip" download="Framer Inventory 3">
+					<a id="pro-download-track-button" class="button pro-section-button-download" href="https://sketchpacks-api.herokuapp.com/v1/plugins/com.addleimb.framer-inventory/download" download="Framer Inventory 3">
 						<p>Download</p>
 					</a>
 				</div>


### PR DESCRIPTION
By using `https://sketchpacks-api.herokuapp.com/v1/plugins/com.addleimb.framer-inventory/download` as the download URL for your free version, you get the benefit of serving your published releases consistently rather than an archive of your latest commit to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/timurnurutdinov/framerinventory/16)
<!-- Reviewable:end -->
